### PR TITLE
Downgrade to py 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.6-slim
 
 #############################
 # INSTALL PYTHON DEPENDENCIES
@@ -23,7 +23,7 @@ RUN pip install --no-cache-dir -r docker-requirements.txt \
 #############################
 
 # rebase to make a smaller image
-FROM python:3.12-slim
+FROM python:3.6-slim
 
 
 # copy python virtual env (all dependencies) from previous image
@@ -49,7 +49,7 @@ WORKDIR /opt/defender/
 # update environmental variables
 ENV PATH="/opt/venv/bin:$PATH"
 ENV PYTHONPATH="/opt/defender"
-
+ENV STRICT_EXTRACT="1"
 
 
 # one may tune model file / threshold / name via environmental variables

--- a/defender/apps.py
+++ b/defender/apps.py
@@ -1,3 +1,4 @@
+from hashlib import sha256
 from flask import Flask, jsonify, request
 
 
@@ -15,6 +16,8 @@ def create_app(model):
             return resp
 
         bytez = request.data
+
+        print(f"Recived file hash: {sha256(bytez)}")
 
         model = app.config['model']
 

--- a/defender/apps.py
+++ b/defender/apps.py
@@ -17,7 +17,7 @@ def create_app(model):
 
         bytez = request.data
 
-        print(f"Recived file hash: {sha256(bytez)}")
+        print(f"Recived file hash: {sha256(bytez).digest()}")
 
         model = app.config['model']
 

--- a/defender/models/whitebox_mlp_model.py
+++ b/defender/models/whitebox_mlp_model.py
@@ -5,8 +5,6 @@ White-box MLP model adapter for the older HTTP template.
 - Loads: whitebox_mlp.pt, whitebox_scaler.joblib, whitebox_threshold.json, whitebox_model_meta.json
 - Extracts EMBER-style (2381-d) features from raw PE bytes via ember + LIEF.
 """
-
-from __future__ import annotations
 import json
 import os
 from pathlib import Path
@@ -104,14 +102,10 @@ class WhiteboxMLPEmberModel:
         # ---- Feature extractor: EMBER (uses LIEF)
         self._ember_ok = False
         self.extractor = None
-        try:
-            import ember  # noqa: F401
-            # Delay import to here to avoid import errors at module import time
-            import ember as _ember
-            self.extractor = _ember.PEFeatureExtractor()
-            self._ember_ok = True
-        except Exception:
-            self._ember_ok = False  # You can vendor the extractor if needed
+
+        import ember as _ember
+        self.extractor = _ember.PEFeatureExtractor()
+        self._ember_ok = True
 
     # ----------------------- Public API -----------------------
     def predict(self, bytez: bytes) -> int:

--- a/docker-requirements.txt
+++ b/docker-requirements.txt
@@ -4,11 +4,12 @@ gevent>=1.4.0
 envparse
 annoy
 pefile
-tqdm<5,>=4.60
-numpy
-pandas
-lightgbm
+tqdm==4.31.0
+numpy==1.16.3
+pandas==0.24.2
+lightgbm==2.2.3
 lief==0.9.0
-scikit-learn
+scikit-learn==0.20.3
 requests
+joblib<1.2
 torch

--- a/docker-requirements.txt
+++ b/docker-requirements.txt
@@ -8,8 +8,7 @@ tqdm<5,>=4.60
 numpy
 pandas
 lightgbm
-lief
+lief==0.9.0
 scikit-learn
 requests
-lief
 torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@
 flask>=1.1.2
 gevent>=1.4.0
 envparse
-annoy
+# annoy
 numpy
 tqdm
 pefile
 requests
 joblib
-scikit-leran
+scikit-learn

--- a/test/__main__.py
+++ b/test/__main__.py
@@ -1,4 +1,5 @@
 import argparse
+from hashlib import sha256
 from test import informational, measure_efficacy, MAXFILESIZE, TIMEOUT, TINYIMPORT, get_raw_result
 import json
 import pathlib


### PR DESCRIPTION
The issue was an ember-lief version incomparability that causes the feature extraction to fail silently and return all zeros instead of the features.
We need to downgrade to py 3.6 since that is the last version that has wheels for lief 0.9.0 which ember requires. 
This breaks the joblib load since joblib saves the standardScalar with a modern scikitlearn version. The latest version supported for py 3.6 is incompadible. 
Can you retrain the model with the pinned verison of scikit learn? 